### PR TITLE
Meteor Google Group replaced with Meteor Forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Send a pull request or just open an [issue](https://github.com/ericdouglas/Meteo
 
 # Community
 
-1. [Meteor Google Group](https://groups.google.com/forum/?fromgroups#!forum/meteor-talk)
+1. [Meteor Forum](https://forums.meteor.com/)
 1. [IRC Channel on freenode](http://meteor.com/irc)
 1. [Meteor on Twitter](https://twitter.com/meteorjs)
 1. [Learn Meteor Properly - Facebook Group](https://www.facebook.com/groups/1498505377066142/)


### PR DESCRIPTION
Meteor Google Group has been closed (https://groups.google.com/forum/?fromgroups#!topic/meteor-talk/elkc4I2seGY). Instead, Meteor Forum (https://forums.meteor.com/) is online.

I've removed the Google Groups link because it doesn't serve to people looking for communities anymore.